### PR TITLE
feat: implement git restore command to revert files to HEAD state

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod init;
 pub mod log;
 pub mod merge;
 pub mod push;
+pub mod restore;
 pub mod revert;
 
 pub use add::git_add;
@@ -18,4 +19,5 @@ pub use init::git_init;
 pub use log::git_log;
 pub use merge::git_merge;
 pub use push::git_push;
+pub use restore::git_restore;
 pub use revert::git_revert;

--- a/src/commands/restore.rs
+++ b/src/commands/restore.rs
@@ -1,0 +1,53 @@
+use git2::{build::CheckoutBuilder, Error, Repository};
+
+pub fn git_restore(path: &str) -> Result<(), Error> {
+    let repo = Repository::open(".")?;
+    let head = repo.head()?;
+    let commit = head.peel_to_commit()?;
+    let binding = commit.tree()?;
+    let tree = binding.as_object();
+    let mut checkout_opts = CheckoutBuilder::new();
+    checkout_opts.path(path);
+    checkout_opts.force(); // --force
+    repo.checkout_tree(&tree, Some(&mut checkout_opts))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{get_repo, write_dummy_add_commit};
+    use serial_test::serial;
+    use std::fs;
+
+    #[test]
+    #[serial]
+    fn test_git_restore() {
+        let repo = get_repo();
+        // 초기 HEAD 커밋이 없으면 더미 커밋을 수행합니다.
+        if repo.head().is_err() {
+            write_dummy_add_commit();
+        }
+
+        let file_name = "restore_test_file.txt";
+        let original_content = "original content";
+        // 파일 생성 후 add, commit 수행
+        fs::write(file_name, original_content).expect("파일 작성 실패");
+        crate::commands::git_add(file_name).expect("파일 stage 실패");
+        crate::commands::git_commit("commit original content").expect("커밋 실패");
+
+        // 파일 내용을 변경
+        let modified_content = "modified content";
+        fs::write(file_name, modified_content).expect("파일 수정 실패");
+
+        // git_restore를 호출하여 파일 내용을 HEAD 상태로 복원
+        git_restore(file_name).expect("restore 실패");
+
+        // 파일 내용을 확인하여 복원이 제대로 되었는지 검증
+        let restored_content = fs::read_to_string(file_name).expect("파일 읽기 실패");
+        assert_eq!(
+            restored_content, original_content,
+            "복원된 파일 내용이 일치하지 않음"
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,17 @@ pub fn main() -> Result<(), git2::Error> {
                     }
                 }
             }
+            "restore" => {
+                if tokens.len() < 2 {
+                    println!("복원할 파일 경로를 입력해주세요.");
+                } else {
+                    if let Err(e) = commands::git_restore(tokens[1]) {
+                        println!("restore error: {}", e);
+                    } else {
+                        println!("파일 복원 완료: {}", tokens[1]);
+                    }
+                }
+            }
             "log" => match commands::git_log() {
                 Ok(logs) => {
                     println!("커밋 로그:");


### PR DESCRIPTION
close: #25 
git2에 restore라는 명령어가 직접적으로 구현되어 있지는 않았다. 그래서 HEAD를 이동시키는 방법으로 restore 구현